### PR TITLE
Better `random-1.3` compatibilty

### DIFF
--- a/.github/workflows/haskell.yaml
+++ b/.github/workflows/haskell.yaml
@@ -50,7 +50,7 @@ jobs:
             ghc: 9.8.4
             stack-yaml: stack.yaml
           - resolver: lts-24
-            ghc: 9.10.2
+            ghc: 9.10.3
             stack-yaml: stack.yaml
           - resolver: nightly
             ghc: 9.12.2

--- a/ImpSpec.cabal
+++ b/ImpSpec.cabal
@@ -65,7 +65,7 @@ library
     prettyprinter >=1.7,
     prettyprinter-ansi-terminal >=1.1.2,
     quickcheck-transformer,
-    random >=1.2,
+    random ^>=1.2,
     text,
     unliftio,
 

--- a/ImpSpec.cabal
+++ b/ImpSpec.cabal
@@ -28,7 +28,7 @@ tested-with:
   ghc ==9.4.8
   ghc ==9.6.6
   ghc ==9.8.2
-  ghc ==9.10.1
+  ghc ==9.10.3
 
 source-repository head
   type: git

--- a/ImpSpec.cabal
+++ b/ImpSpec.cabal
@@ -65,7 +65,7 @@ library
     prettyprinter >=1.7,
     prettyprinter-ansi-terminal >=1.1.2,
     quickcheck-transformer,
-    random ^>=1.2,
+    random >=1.2,
     text,
     unliftio,
 

--- a/src/Test/ImpSpec/Internal.hs
+++ b/src/Test/ImpSpec/Internal.hs
@@ -13,8 +13,6 @@
 {-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
--- Due to usage of `split`
-{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Test.ImpSpec.Internal where
 

--- a/src/Test/ImpSpec/Random.hs
+++ b/src/Test/ImpSpec/Random.hs
@@ -5,8 +5,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
--- Due to usage of `uniformShortByteString`
-{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Test.ImpSpec.Random where
 

--- a/src/Test/ImpSpec/Random.hs
+++ b/src/Test/ImpSpec/Random.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -76,7 +77,11 @@ uniformByteStringM n = askStatefulGen >>= R.uniformByteStringM n
 {-# INLINE uniformByteStringM #-}
 
 uniformShortByteStringM :: HasStatefulGen a m => Int -> m ShortByteString
+#if MIN_VERSION_random(1,3,0)
+uniformShortByteStringM n = askStatefulGen >>= R.uniformShortByteStringM n
+#else
 uniformShortByteStringM n = askStatefulGen >>= R.uniformShortByteString n
+#endif
 {-# INLINE uniformShortByteStringM #-}
 
 -- | Lifted version of `QC.arbitrary`.


### PR DESCRIPTION
This uses CPP instead of `-Wno-deprecations`