### PR TITLE
Bump package version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `ImpSpec`
 
+## 0.2.0.1
+
+* Enable compatibility with `random-1.3`
+
 ## 0.2.0.0
 
 * Add explicit `forall` for `uniformM`, `uniformRM`, `uniformListM`, `uniformListRM` and `arbitrary`

--- a/ImpSpec.cabal
+++ b/ImpSpec.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name: ImpSpec
-version: 0.2.0.0
+version: 0.2.0.1
 license: Apache-2.0
 license-file: LICENSE
 maintainer: operations@iohk.io


### PR DESCRIPTION
Although #7 added a new orphan instance, it's in an `Internal` module and therefore not part of the API